### PR TITLE
Implement by loci comparison.

### DIFF
--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -148,16 +148,11 @@ let () =
                         Specify multiple classes to get separate analysis.")
     in
     let loci_arg =
-      let loci_converter =
-        let parser_ s = `Ok s in
-        let printer f c = Format.fprintf f "%s" c in
-        parser_, printer
-      in
-      Arg.(value & opt_all loci_converter []
+      Arg.(value & opt_all string []
             & info ["l"; "loci"]
                 ~doc:"MHC loci along which to partition the similarity analysis: a string prefix.\
                       Specify a prefix that is used to group loci (ex. \"A\", \"B\", \"DRB1\", etc.).\
-                      Specify multiple loci to get separate analysis.\
+                      Specify multiple loci to get separate analyses.\
                       This argument will supersede any class grouping arguments.")
     in
     Term.(const compare $ resolution_arg $ classes_arg $ loci_arg $ seq_arg $ opt_arg $ ath_arg

--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -26,10 +26,11 @@ let multiple seqlst optlst athlst do_not_prefix =
   |> List.concat
   |> Output.out_channel stdout
 
-let compare resolution classes seqlst optlst athlst =
+let compare resolution classes loci seqlst optlst athlst =
   let classes = match classes with | [] -> None | l -> Some l in
+  let loci = match loci with | [] -> None | l -> Some l in
   Compare.nested_maps seqlst optlst athlst
-  |> Compare.output ?resolution ?classes stdout
+  |> Compare.output ?resolution ?classes ?loci stdout
 
 let () =
   let open Cmdliner in
@@ -146,7 +147,19 @@ let () =
                 ~doc:"MHC class along which to partition the similarity analysis: Must be 1 or 2.\
                         Specify multiple classes to get separate analysis.")
     in
-    Term.(const compare $ resolution_arg $ classes_arg $ seq_arg $ opt_arg $ ath_arg
+    let loci_arg =
+      let loci_converter =
+        let parser_ s = `Ok s in
+        let printer f c = Format.fprintf f "%s" c in
+        parser_, printer
+      in
+      Arg.(value & opt_all loci_converter []
+            & info ["l"; "loci"]
+                ~doc:"MHC loci along which to partition the similarity analysis: a string prefix.\
+                      Specify a prefix that is used to group loci (ex. \"A\", \"B\", \"DRB1\", etc.).\
+                      Specify multiple loci to get separate analysis.")
+    in
+    Term.(const compare $ resolution_arg $ classes_arg $ loci_arg $ seq_arg $ opt_arg $ ath_arg
         , info "compare"
             ~doc:"Scan multiple directories (of possibly different formats) and compare the results after aggregating on a per run basis.")
   in

--- a/src/lib/hlarp.ml
+++ b/src/lib/hlarp.ml
@@ -367,7 +367,7 @@ module Compare = struct
 
   (* ?classes: Allow more than one HLA_class to do the analysis on, but default
       to ignoring the distinction. *)
-  let output ?resolution ?classes oc nested_map_output =
+  let output ?resolution ?classes ?loci oc nested_map_output =
     let select = select_allele ?resolution in
     let cmj, group, default_indent, suffix, nc =
       match classes with

--- a/src/lib/hlarp.ml
+++ b/src/lib/hlarp.ml
@@ -367,7 +367,10 @@ module Compare = struct
         (a, count_consecutive_doubles l |> compress_counts))
 
   (* ?classes: Allow more than one HLA_class to do the analysis on, but default
-      to ignoring the distinction. *)
+      to ignoring the distinction.
+     ?loci: Allow more than one HLA loci to do the analysis on, superseding
+      any classes argument, but default to ignoring the distinction. Specify
+      a string prefix that is used group alleles. *)
   let output ?resolution ?classes ?loci oc nested_map_output =
     let select = select_allele ?resolution in
     let cmj, group, default_indent, suffix, nc =


### PR DESCRIPTION
```
$ ./hlarp_cli.native compare --resolution 2 -l A -l B -l C -l DRB1 --optitype /path/to/opti/results/ -a /path/to/ath/res/
....
Sample1            	jacard similarities: 0.00 0.33 0.33 0.00
	A:	A*23:01	OptiType
		A*34:02	OptiType
	B:	B*13:02	OptiType;ATHLATES
		B*81:01	OptiType
		B*81:03	ATHLATES
	C:	C*08:04	OptiType;ATHLATES
		C*18:01	OptiType
		C*18:02	ATHLATES
	DRB1:	DRB1*12:01	ATHLATES
		DRB1*15:03	ATHLATES
Sample2          	jacard similarities: 1.00 0.33 1.00 0.00
	A:	A*29:02	OptiType;ATHLATES
		A*32:01	OptiType;ATHLATES
	B:	B*15:16	OptiType;ATHLATESx2
		B*81:01	OptiType
	C:	C*16:01	OptiType;ATHLATES
		C*18:01	OptiType;ATHLATES
	DRB1:	DRB1*01:02	ATHLATES
		DRB1*11:01	ATHLATES
Average jacard similarities across runs: 0.54 0.60 0.51 0.07
```