### PR TITLE
Kl div

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -5,4 +5,4 @@
 #require "cmdliner"
 
 #directory "_build/src/lib"
-#load_rec "hlarp.cmo"
+#load_rec "hlarp.cma"

--- a/.ocamlinit
+++ b/.ocamlinit
@@ -3,6 +3,8 @@
 #require "re.posix"
 #require "re.glob"
 #require "cmdliner"
+#require "oml"
 
 #directory "_build/src/lib"
 #load_rec "hlarp.cma"
+open Std

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES_INSTALL=nonstd re cmdliner
+PACKAGES_INSTALL=nonstd re cmdliner oml
 PACKAGES=$(PACKAGES_INSTALL) re.posix re.glob
 
 .PHONY: default clean build deps install uninstall

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,15 @@ clean:
 	ocamlbuild -clean
 	rm -f ./hlarp
 
-
 install:
-	ocamlfind install hlarp META\
-		_build/src/lib/hlarp.a\
-		_build/src/lib/hlarp.o\
-		_build/src/lib/hlarp.cma\
-		_build/src/lib/hlarp.cmi\
-		_build/src/lib/hlarp.cmo\
-		_build/src/lib/hlarp.cmx\
-		_build/src/lib/hlarp.cmxa\
+	ocamlfind install hlarp META \
+		_build/src/lib/hlarp.a \
+		_build/src/lib/hlarp.o \
+		_build/src/lib/hlarp.cma \
+		_build/src/lib/hlarp.cmi \
+		_build/src/lib/hlarp.cmo \
+		_build/src/lib/hlarp.cmx \
+		_build/src/lib/hlarp.cmxa \
 		_build/src/lib/hlarp.cmxs
 
 uninstall:

--- a/_tags
+++ b/_tags
@@ -1,1 +1,2 @@
+true: annot, bin_annot, principal
 <src/lib/*.cmx> and not <src/lib/hlarp.cm*> : for-pack(Hlarp)

--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -112,10 +112,10 @@ let () =
         & info arg_lst ~docv:"DIR"
             ~doc:(sprintf "Directory to search for %s output (repeatable)." name))
   in
-  let seq_arg = to_directory_arg "Seq2HLA" ["s"; "seq2HLA"] in
-  let opt_arg = to_directory_arg "Optitype" ["o"; "optitype"] in
-  let ath_arg = to_directory_arg "ATHLATES" ["a"; "athlates"] in
-  let pro_arg = to_directory_arg "Prohlatype" ["p"; "prohlatype"] in
+  let seq_arg = to_directory_arg "Seq2HLA" [ Compare.seq2hl_file_arg ] in
+  let opt_arg = to_directory_arg "Optitype" [ Compare.optitype_file_arg ] in
+  let ath_arg = to_directory_arg "ATHLATES" [ Compare.athlates_file_arg ] in
+  let pro_arg = to_directory_arg "Prohlatype" [ Compare.prohlatype_file_arg ] in
   let multiple =
     let pre_flg =
       Arg.(value & flag & info ["prefix"]
@@ -163,7 +163,7 @@ let () =
     in
     let files_arg =
       Arg.(value & opt_all file []
-          & info ["hlarp-file"] ~docv:"FILE"
+          & info [ Compare.hlarp_file_arg ] ~docv:"FILE"
             ~doc:"Load, parse and use for comparison a file previously written by the aggregate format.")
     in
     let max_allele_rows_to_print_arg =

--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -25,11 +25,14 @@ let multiple seqlst optlst athlst prolst do_not_prefix =
   |> List.concat
   |> Output.out_channel stdout
 
-let compare resolution classes loci seqlst optlst athlst prolst filelst =
+let compare resolution classes loci max_allele_rows_to_print metrics summary_by
+  (* Input *)
+  seqlst optlst athlst prolst filelst =
   let classes = match classes with | [] -> None | l -> Some l in
   let loci = match loci with | [] -> None | l -> Some l in
-  Compare.nested_maps seqlst optlst athlst prolst filelst
-  |> Compare.output ?resolution ?classes ?loci stdout
+  let nmp  = Compare.nested_maps ~seqlst ~optlst ~athlst ~prolst ~filelst () in
+  let azo  = Compare.analyze_samples ?loci ?resolution ?classes ~metrics nmp in
+  Compare.output ?max_allele_rows_to_print ~summary_by stdout azo
 
 let () =
   let open Cmdliner in
@@ -160,10 +163,33 @@ let () =
     in
     let files_arg =
       Arg.(value & opt_all file []
-          & info ["hlarp-file"] ~docv:"Hlarp output file"
+          & info ["hlarp-file"] ~docv:"FILE"
             ~doc:"Load, parse and use for comparison a file previously written by the aggregate format.")
     in
+    let max_allele_rows_to_print_arg =
+      Arg.(value & opt (some int) None
+          & info ["max-allele-rows-to-print"]
+              ~docv:"NON NEGATIVE INTEGER"
+              ~doc:"The number of per sample per comparison alleles to \
+                    display. Defaults to 0")
+    in
+    let metrics_flag =
+      Arg.(value & vflag_all [`Jaccard]
+        [ `Jaccard, info ~doc:"Jaccard similarity" ["jaccard"]
+        ; `KLDiv,   info ~doc:"Kullbeck Leibler divergence" ["kldiv"]
+        ])
+    in
+    let summary_by_arg =
+      Arg.(value & vflag `Mean
+        [ `Mean,    info ~doc:"Report the mean across samples by comparison." ["mean-summary"]
+        ; `Median,  info ~doc:"Report the median across samples by comparison." ["median-summary"]
+        ])
+    in
     Term.(const compare $ resolution_arg $ classes_arg $ loci_arg
+            $ max_allele_rows_to_print_arg
+            $ metrics_flag
+            $ summary_by_arg
+            (* Input *)
             $ seq_arg $ opt_arg $ ath_arg $ pro_arg
             $ files_arg
         , info "compare"

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -123,34 +123,6 @@ let loci_prefix_filter p ai =
 let hla_class_filter c ai =
   ai.hla_class = c
 
-  (*
-let compute_mean_jaccard ?by ?(count_homozygous_2x=true) select typer_assoc =
-  let filter = to_filter by in
-  let set_of_ailst =
-    List.fold_left ~init:AlleleSet.empty ~f:(fun s ai ->
-      if filter ai then
-        let ai_sel = select ai in
-        if count_homozygous_2x && AlleleSet.mem ai_sel s then
-          AlleleSet.add (ai_sel ^ "2") s
-        else
-          AlleleSet.add ai_sel s
-      else
-        s)
-  in
-  let as_sets =
-    List.map ~f:(fun (typer, allele_lst) ->
-      let s = set_of_ailst allele_lst in
-      (typer, s)) typer_assoc
-  in
-  let sum_jaccard_index =
-    list_fold_over_all_pairs as_sets ~init:0.
-      ~f:(fun s ((_t1,s1), (_t2,s2)) -> s +. jaccard s1 s2)
-  in
-  let nf = float (List.length as_sets) in
-  let num_pairs = nf *. (nf -. 1.) /. 2. in
-  sum_jaccard_index /. num_pairs
-  *)
-
 let count_consecutive_doubles = function
   | []      -> []
   | h :: [] -> [ h, 1]

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -210,9 +210,9 @@ let normalize sum assoc =
   let open Oml in
   if Util.is_degenerate sum || sum = 0. then
     let oon = 1. /. (float (List.length assoc)) in
-      List.map ~f:(fun (k, _) -> k, oon) assoc
-    else
-      List.map ~f:(fun (k, ai) -> k, ai.confidence /. sum) assoc
+    List.map ~f:(fun (k, _) -> k, oon) assoc
+  else
+    List.map ~f:(fun (k, ai) -> k, ai.confidence /. sum) assoc
 
 let to_metric = function
   | `Jaccard ->
@@ -225,8 +225,10 @@ let to_metric = function
         try
           Statistics.Measures.discrete_kl_divergence ~p ~q
         with (Invalid_argument m) ->
-          eprintf "%s returning nan\n" m;
-          nan
+          eprintf "%s returning infinity. p %s vs q %s\n" m
+            (String.concat ";" (List.map p ~f:(fun (s, c) -> sprintf "%s:%0.2f" s c)))
+            (String.concat ";" (List.map q ~f:(fun (s, c) -> sprintf "%s:%0.2f" s c))) ;
+          infinity
 
 (* ?classes: Allow more than one HLA_class to do the analysis on, but default
     to ignoring the distinction.

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -265,7 +265,10 @@ let output_aggregates ?(summary_by=`Mean) oc smpl_width widths analyze_samples_o
         List.map2 acc metrics_eval ~f:(fun lst v -> v :: lst)))
   in
   let open Oml.Statistics.Descriptive in
-  fprintf oc "%-*s" smpl_width " ";
+  fprintf oc "%-*s" smpl_width
+    (match summary_by with
+      | `Mean -> "mean"
+      | `Median -> "median");
   List.map2 widths all_metrics ~f:(fun w lst ->
     let reduced =
       List.map lst ~f:(fun mtrlst ->

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -1,36 +1,47 @@
 
 open Std
 
-module SMap = Map.Make (struct type t = string let compare = compare end)
-module SSet = Set.Make (struct type t = string let compare = compare end)
+module SampleMap = Map.Make (struct type t = sample let compare = compare end)
+module AlleleMap = Map.Make (struct type t = allele let compare = compare end)
 
-let to_prefix name lst =
+type directory = string
+type scanner = directory -> (sample * info list) list
+
+type source = string
+
+(* When we want to compare multiple runs from the same source type
+   (ex. Seq2HLA dir1, dir2 ..) use this method to create a prefix function
+   that appends a number to the source if there are multiple and
+   create source. *)
+let to_source (name : string) (lst : 'a list) : (int -> source) =
   if List.length lst > 1 then
     (fun i -> sprintf "%s%d" name (i + 1))
   else
     fun _ -> name
 
-let nested_maps seqlst optlst athlst prolst filelst =
-  let add_to_run_map name scan dirlst run_map =
-    let prefix = to_prefix name dirlst in
-    List.foldi dirlst ~init:run_map ~f:(fun i rmp dir ->
-        let p = prefix i in
-        scan dir
-        |> List.fold_left ~init:rmp ~f:(fun rmp (run, info_lst) ->
-            match SMap.find run rmp with
-            | lst                 -> SMap.add run ((p,info_lst) :: lst) rmp
-            | exception Not_found -> SMap.add run ((p,info_lst) :: []) rmp))
-  in
-  let load_file file =
+let add_to_sample_map ~source_name (scan : scanner) (dirlst : directory list) sample_map =
+  let prefix = to_source source_name dirlst in
+  List.foldi dirlst ~init:sample_map ~f:(fun i rmp dir ->
+      let p = prefix i in
+      scan dir
+      |> List.fold_left ~init:rmp ~f:(fun rmp (sample, info_lst) ->
+          match SampleMap.find sample rmp with
+          | lst                 -> SampleMap.add sample ((p,info_lst) :: lst) rmp
+          | exception Not_found -> SampleMap.add sample ((p,info_lst) :: []) rmp))
+
+(* Use previously written Hlarp output files as comparison source.  *)
+module HlarpOutputFiles = struct
+
+  let load_file ~use_basename (basename, file) =
     let ic = open_in file in
     let _hdr = input_line ic in
     let rec loop m =
       try
         let line = input_line ic in
-        let run, info =
+        let sample, info =
           match Re.split (Re.char ',' |> Re.compile) line with
-          | cls_s :: all_s :: qul_s :: con_s :: run_s :: [] ->
-              run_s
+          | cls_s :: all_s :: qul_s :: con_s :: sample :: [] ->
+              sample
               , { hla_class =
                     if cls_s = "1" then I else
                       if cls_s = "2" then II else
@@ -43,75 +54,88 @@ let nested_maps seqlst optlst athlst prolst filelst =
                     (sprintf "can't parse Hlarp input line %s from %s"
                       line file)
         in
-        match SMap.find run m with
-        | (f, lst) when f = file -> loop (SMap.add run (file, info :: lst) m)
-        | exception Not_found    -> loop (SMap.add run (file, info :: []) m)
-        | (nf, _)                ->
-            invalid_arg (sprintf "encountered another file %s while parsing: %s" nf file)
+        let key = if use_basename then basename else file in
+        match SampleMap.find sample m with
+        | (f, lst) when f = key -> loop (SampleMap.add sample (key, info :: lst) m)
+        | exception Not_found   -> loop (SampleMap.add sample (key, info :: []) m)
+        | (nf, _)               -> invalid_arg
+              (sprintf "encountered another file %s while parsing: %s" nf key)
       with End_of_file ->
         m
     in
-    loop SMap.empty
-  in
-  let add_hlarp_files filelst run_map =
-    List.fold_left filelst ~init:run_map ~f:(fun m file ->
-      let fm = load_file file in
-      let fmm = SMap.map (fun fl -> fl :: []) fm in
-      SMap.union (fun _run l1 l2 -> Some (l1 @ l2)) m fmm)
-  in
-  SMap.empty
-  |> add_to_run_map "seq2HLA"  Seq2HLA.scan_directory seqlst
-  |> add_to_run_map "OptiType" OptiType.scan_directory optlst
-  |> add_to_run_map "ATHLATES" Athlates.scan_directory athlst
-  |> add_to_run_map "Prohlatype" Prohlatype.scan_directory prolst
-  |> add_hlarp_files filelst
-  |> SMap.bindings
+    loop SampleMap.empty
 
-let fold_over_all_pairs ~f ~init lst =
+  let add filelst sample_map =
+    let with_basenames =
+      List.map filelst ~f:(fun file -> Filename.basename file, file)
+      |> List.sort ~cmp:compare
+    in
+    let compare_by_first (b1, _) (b2, _) = compare b1 b2 in
+    let use_basename = not (List.contains_dup with_basenames ~compare:compare_by_first) in
+    List.fold_left with_basenames ~init:sample_map ~f:(fun m bfp ->
+      let fm = load_file ~use_basename bfp in
+      let fmm = SampleMap.map (fun fl -> fl :: []) fm in
+      SampleMap.union (fun _sample l1 l2 -> Some (l1 @ l2)) m fmm)
+
+end
+
+let nested_maps ?(seqlst=[]) ?(optlst=[]) ?(athlst=[]) ?(prolst=[]) ?(filelst=[]) () =
+  SampleMap.empty
+  |> add_to_sample_map ~source_name:"seq2HLA"  Seq2HLA.scan_directory seqlst
+  |> add_to_sample_map ~source_name:"OptiType" OptiType.scan_directory optlst
+  |> add_to_sample_map ~source_name:"ATHLATES" Athlates.scan_directory athlst
+  |> add_to_sample_map ~source_name:"Prohlatype" Prohlatype.scan_directory prolst
+  |> HlarpOutputFiles.add filelst
+  |> SampleMap.bindings
+
+let list_fold_over_all_pairs ~f ~init lst =
   let rec loop init = function
     | []     -> init
-    | h :: t -> loop (List.fold_left ~init ~f:(fun acc te -> f acc (h, te)) t) t
+    | h :: t -> loop (List.fold_left ~init ~f:(fun acc te -> f acc h te) t) t
   in
   loop init lst
 
 let colon_regex = Re_posix.compile_pat ":"
 
-let select_allele ?resolution ai =
+let to_allele ?resolution ai =
   match resolution with
-  | None -> ai.allele
+  | None   -> ai.allele
   | Some n -> List.take (Re.split colon_regex ai.allele) n
               |> String.concat ":"
 
+module AlleleSet = Set.Make (struct type t = allele let compare = compare end)
+
 let jaccard ?(zero_on_empty=true) s1 s2 =
-  let n1 = SSet.cardinal s1 in
-  let n2 = SSet.cardinal s2 in
+  let n1 = AlleleSet.cardinal s1 in
+  let n2 = AlleleSet.cardinal s2 in
   if n1 = 0 && n2 = 0 then
     1.
   else if zero_on_empty && (n1 = 0 || n2 = 0) then
     0.
   else
-    let inter = SSet.inter s1 s2 |> SSet.cardinal in
-    let union = SSet.union s1 s2 |> SSet.cardinal in
+    let inter = AlleleSet.inter s1 s2 |> AlleleSet.cardinal in
+    let union = AlleleSet.union s1 s2 |> AlleleSet.cardinal in
     (float inter) /. (float union)
 
-let to_filter = function
-  | None                  -> fun _ -> true
-  | Some (`HLAClass c)    -> fun ai -> ai.hla_class = c
-  | Some (`LociPrefix p)  -> fun ai -> Re.execp (Re_posix.compile_pat ("^" ^ p)) ai.allele
+let loci_prefix_filter p ai =
+  Re.execp (Re_posix.compile_pat ("^" ^ p)) ai.allele
 
+let hla_class_filter c ai =
+  ai.hla_class = c
+
+  (*
 let compute_mean_jaccard ?by ?(count_homozygous_2x=true) select typer_assoc =
   let filter = to_filter by in
-  let set_of_ailst lst =
-    List.fold_left lst ~init:SSet.empty
-      ~f:(fun s ai ->
-            if filter ai then
-              let ai_sel = select ai in
-              if count_homozygous_2x && SSet.mem ai_sel s then
-                SSet.add (ai_sel ^ "2") s
-              else
-                SSet.add (select ai) s
-            else
-              s)
+  let set_of_ailst =
+    List.fold_left ~init:AlleleSet.empty ~f:(fun s ai ->
+      if filter ai then
+        let ai_sel = select ai in
+        if count_homozygous_2x && AlleleSet.mem ai_sel s then
+          AlleleSet.add (ai_sel ^ "2") s
+        else
+          AlleleSet.add ai_sel s
+      else
+        s)
   in
   let as_sets =
     List.map ~f:(fun (typer, allele_lst) ->
@@ -119,19 +143,20 @@ let compute_mean_jaccard ?by ?(count_homozygous_2x=true) select typer_assoc =
       (typer, s)) typer_assoc
   in
   let sum_jaccard_index =
-    fold_over_all_pairs as_sets ~init:0.
+    list_fold_over_all_pairs as_sets ~init:0.
       ~f:(fun s ((_t1,s1), (_t2,s2)) -> s +. jaccard s1 s2)
   in
   let nf = float (List.length as_sets) in
   let num_pairs = nf *. (nf -. 1.) /. 2. in
   sum_jaccard_index /. num_pairs
+  *)
 
 let count_consecutive_doubles = function
   | []      -> []
   | h :: [] -> [ h, 1]
   | h :: t  ->
     let rec loop p c acc = function
-      | []     -> List.rev ((p, c) :: acc)
+      | []                -> List.rev ((p, c) :: acc)
       | h :: t when h = p -> loop p (c + 1) acc t
       | h :: t            -> loop h 1 ((p,c) :: acc) t
     in
@@ -140,81 +165,189 @@ let count_consecutive_doubles = function
 let compress_counts =
   List.map ~f:(fun (a,c) -> if c < 2 then a else sprintf "%sx%d" a c)
 
-let group_similarities ?by select typer_assoc =
-  let filter = to_filter by in
-  List.fold_left typer_assoc ~init:SMap.empty
-    ~f:(fun m (typer, allele_lst) ->
-      List.fold_left allele_lst ~init:m ~f:(fun m ai ->
-        if not (filter ai) then
-          m
-        else
-          let ai_sel = select ai in
-          match SMap.find ai_sel m with
-          | lst                 -> SMap.add ai_sel (typer :: lst) m
-          | exception Not_found -> SMap.add ai_sel (typer :: []) m))
-  |> SMap.bindings
+let specific_grouped_view ~typer1 ~ilist1 ~typer2 ~ilist2 =
+  let to_fold typer =
+    fun m (ai, _v) ->
+      match AlleleMap.find ai m with
+      | lst                 -> AlleleMap.add ai (typer :: lst) m
+      | exception Not_found -> AlleleMap.add ai (typer :: []) m
+  in
+  List.fold_left ilist1 ~init:AlleleMap.empty ~f:(to_fold typer1)
+  |> fun m -> List.fold_left ilist2 ~init:m ~f:(to_fold typer2)
+  |> AlleleMap.bindings
   |> List.sort ~cmp:compare
   |> List.map ~f:(fun (a, l) ->
       (a, count_consecutive_doubles l |> compress_counts))
+
+let against_all_pairs eval nested_map_bindings =
+  List.map nested_map_bindings ~f:(fun (sample, type_assoc) ->
+    sample
+    , list_fold_over_all_pairs type_assoc ~init:[]
+        ~f:(fun acc ((typer1,_) as p1) ((typer2, _) as p2) ->
+              let res = sprintf "%s vs %s" typer1 typer2 in
+              let e   = eval p1 p2 in
+              (res, e) :: acc))
+
+type comparison =
+  { metrics_eval  : float list
+  ; grouped_view  : (allele * string list) list
+  }
+
+let args_to_projections ?loci ?classes mlst spec_gv data =
+  let projects =
+    match loci, classes with
+    | Some loci, _              -> List.map loci ~f:(loci_prefix_filter)
+    | None,      None           -> [ fun _ -> true ]
+    | None,      (Some classes) -> List.map classes ~f:(hla_class_filter)
+  in
+  let eval ((_t1, ilist1) as itassoc1) ((_t2, ilist2) as itassoc2) =
+    { metrics_eval=
+        List.map projects ~f:(fun fltr ->
+          let f1 = List.filter ilist1 ~f:fltr in
+          let f2 = List.filter ilist2 ~f:fltr in
+          List.map mlst ~f:(fun k -> k f1 f2))
+        |> List.concat
+    ; grouped_view = spec_gv ~itassoc1 ~itassoc2
+    }
+  in
+  against_all_pairs eval data
+
+(* Reduce the [info]'s to have a unique allele resolution.
+   ex. A*01:01:01:01 -> A*01:01 and 2nd pair will get "x2" appended. *)
+let keyed_by_allele_info_assoc ?resolution ?(count_homozygous_2x=true) =
+  let to_allele = to_allele ?resolution in
+  List.fold_left ~init:[] ~f:(fun acc ai ->
+    let k = to_allele ai in
+    if List.mem_assoc k acc then
+      (k ^ "x2", ai) :: acc
+    else
+      (k, ai) :: acc)
+
+let set_of_assoc_keys l =
+  (AlleleSet.of_list (List.map ~f:fst l))
+
+let sum_confidence =
+  List.fold_left ~f:(fun s (_, ai) -> s +. ai.confidence) ~init:0.
+
+let normalize sum assoc =
+  let open Oml in
+  if Util.is_degenerate sum || sum = 0. then
+    let oon = 1. /. (float (List.length assoc)) in
+      List.map ~f:(fun (k, _) -> k, oon) assoc
+    else
+      List.map ~f:(fun (k, ai) -> k, ai.confidence /. sum) assoc
+
+let to_metric = function
+  | `Jaccard ->
+      fun asc1 asc2 -> jaccard (set_of_assoc_keys asc1) (set_of_assoc_keys asc2)
+  | `KLDiv   ->
+      let open Oml in
+      fun asc1 asc2 ->
+        let p = normalize (sum_confidence asc1) asc1 in
+        let q = normalize (sum_confidence asc2) asc2 in
+        try
+          Statistics.Measures.discrete_kl_divergence ~p ~q
+        with (Invalid_argument m) ->
+          eprintf "%s returning nan\n" m;
+          nan
 
 (* ?classes: Allow more than one HLA_class to do the analysis on, but default
     to ignoring the distinction.
     ?loci: Allow more than one HLA loci to do the analysis on, superseding
     any classes argument, but default to ignoring the distinction. Specify
-    a string prefix that is used group alleles. *)
-let output ?resolution ?classes ?loci oc nested_map_output =
-  let select = select_allele ?resolution in
-  let cmj, group, default_indent, suffix, nc =
-    match loci with
-    | Some loci_lst ->
-        (fun typer_assoc ->
-          List.map loci_lst ~f:(fun loci ->
-            compute_mean_jaccard ~by:(`LociPrefix loci) select typer_assoc))
-        , (fun typer_assoc ->
-          List.map loci_lst ~f:(fun loci ->
-            (Some (loci ^ ":\t")
-            , group_similarities ~by:(`LociPrefix loci) select typer_assoc)))
-        , "\t"
-        , "ies"
-        , List.length loci_lst
-    | None ->
-        begin
-          match classes with
-          | None ->
-              (fun typer_assoc -> [ compute_mean_jaccard select typer_assoc ])
-              , (fun typer_assoc -> [ None, group_similarities select typer_assoc ])
-              , ""
-              , "y"
-              , 1
-          | Some hla_classes ->
-              (fun typer_assoc ->
-                List.map hla_classes ~f:(fun hla_class ->
-                  compute_mean_jaccard ~by:(`HLAClass hla_class) select typer_assoc))
-              , (fun typer_assoc ->
-                  List.map hla_classes ~f:(fun hla_class ->
-                    (Some (hla_class_to_string hla_class ^ ":\t")
-                    , group_similarities ~by:(`HLAClass hla_class) select typer_assoc)))
-              , "\t"
-              , "ies"
-              , List.length hla_classes
-        end
+    a string prefix that is used group alleles.  *)
+let analyze_samples ?loci ?classes ?resolution ?count_homozygous_2x ?(metrics=[`Jaccard])
+  nested_map_bindings =
+    let ilist_map = keyed_by_allele_info_assoc ?resolution ?count_homozygous_2x in
+    let metricsf =
+      List.map metrics ~f:(fun m ->
+          let mtr = to_metric m in
+          fun alst1 alst2 ->
+            let ilist1 = ilist_map alst1 in
+            let ilist2 = ilist_map alst2 in
+            mtr ilist1 ilist2)
+    in
+    let spgv ~itassoc1:(typer1, ilist1) ~itassoc2:(typer2, ilist2) =
+      specific_grouped_view ~typer1 ~ilist1:(ilist_map ilist1) ~typer2 ~ilist2:(ilist_map ilist2)
+    in
+    args_to_projections ?loci ?classes metricsf spgv nested_map_bindings
+
+let float_lst_to_str ~sep l =
+  String.concat sep (List.map ~f:(sprintf "%0.2f") l)
+
+let output_aggregates ?(summary_by=`Mean) oc smpl_width widths analyze_samples_output =
+  let sep = "\t" in
+  let _fst, fst_assoc = List.hd_exn analyze_samples_output in
+  let num_comparisons = List.length fst_assoc in
+  let num_metrics     = List.length (List.hd_exn fst_assoc |> snd).metrics_eval in
+  let init = List.init num_comparisons ~f:(fun _ -> List.init num_metrics ~f:(fun _ -> [])) in
+  let all_metrics =
+    List.fold_left analyze_samples_output ~init ~f:(fun lst (_smpl, asc) ->
+      List.map2 lst asc ~f:(fun acc (_, {metrics_eval;_}) ->
+        List.map2 acc metrics_eval ~f:(fun lst v -> v :: lst)))
   in
-  let float_lst_to_str l = String.concat " " (List.map ~f:(sprintf "%0.2f") l) in
-  let ss, n =
-    List.fold_left nested_map_output ~init:(List.init nc ~f:(fun _ -> 0.), 0)
-      ~f:(fun (jc_s, jc_n) (run, typer_assoc) ->
-            let jc_lst = cmj typer_assoc in
-            fprintf oc "%s\tjaccard similarit%s: %s\n" run suffix (float_lst_to_str jc_lst);
-            let group = group typer_assoc in
-            List.iter group ~f:(fun (cls_opt, by_cls_lst) ->
-              List.iteri by_cls_lst ~f:(fun i (a, tlst) ->
-                let s1 =
-                  if i = 0 then Option.value ~default:default_indent cls_opt
-                  else default_indent
-                in
-                fprintf oc "\t%s%s\t%s\n" s1 a (String.concat ";" tlst)));
-            List.map2 ~f:(+.) jc_s jc_lst, jc_n + 1)
+  let open Oml.Statistics.Descriptive in
+  fprintf oc "%-*s" smpl_width " ";
+  List.map2 widths all_metrics ~f:(fun w lst ->
+    let reduced =
+      List.map lst ~f:(fun mtrlst ->
+        let arr = Array.of_list mtrlst in
+        match summary_by with
+        | `Mean -> mean arr
+        | `Median -> median arr) in
+    sprintf "%-*s" w (float_lst_to_str ~sep:", " reduced))
+  |> String.concat sep
+  |> fprintf oc "%s\n"
+
+let output ?(max_allele_rows_to_print=max_int) ?summary_by oc analyze_samples_output =
+  let fst_smpl, fst_assoc = List.hd_exn analyze_samples_output in
+  let join_allele_str (a, lst) =
+    sprintf "%s: %s" a (String.concat "," lst)
   in
-  let nf = float n in
-  let avgs = List.map ~f:(fun x -> x /. nf) ss in
-  fprintf oc "Average jaccard similarit%s across runs: %s\n" suffix (float_lst_to_str avgs)
+  let widths =
+    List.map ~f:(fun (s, r) ->
+      List.fold_left r.grouped_view ~init:(0, String.length s)
+        ~f:(fun (c, x) al ->
+              if c > max_allele_rows_to_print then
+                (c + 1, x)
+              else
+                (c + 1, max x (String.length (join_allele_str al))))
+      |> snd) fst_assoc
+  in
+  let smpl_width = max (String.length "sample") (String.length fst_smpl + 2) in
+  let sep = "\t" in
+  let row_printer comp_assoc =
+    List.map2 ~f:(fun w (s, _) -> sprintf "%*s" w s) widths comp_assoc
+    |> String.concat sep
+    |> fprintf oc "%s\n"
+  in
+  let value_row_printer comp_assoc =
+    List.map2 ~f:(fun w (_, m) ->
+      sprintf "%-*s" w (float_lst_to_str ~sep:", " m.metrics_eval)) widths comp_assoc
+    |> String.concat sep
+    |> fprintf oc "%s\n"
+  in
+  let setup_sub_row =
+    List.map ~f:(fun (_, m) -> List.length m.grouped_view, m.grouped_view)
+  in
+  let sub_row_printer ssr row =
+   List.map2 ~f:(fun w (ng, gv) ->
+      if row < ng then
+        sprintf "%*s" w (join_allele_str (List.nth_exn gv row))
+      else
+        sprintf "%*s" w " ") widths ssr
+    |> String.concat sep
+    |> fprintf oc "%s\n"
+  in
+  fprintf oc "%-*s" smpl_width "sample" ;
+  row_printer fst_assoc;
+  List.iter analyze_samples_output ~f:(fun (sample, comp_assoc) ->
+    fprintf oc "%-*s " smpl_width sample;
+    value_row_printer comp_assoc;
+    let sub_rows = setup_sub_row comp_assoc in
+    let mx_rows = List.fold_left ~init:min_int ~f:(fun x (r, _) -> max x r) sub_rows in
+    for r = 0 to mx_rows - 1 do
+      fprintf oc "%*s " smpl_width " ";
+      sub_row_printer sub_rows r
+    done);
+  output_aggregates oc smpl_width widths ?summary_by analyze_samples_output

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -175,9 +175,10 @@ let specific_grouped_view ~typer1 ~ilist1 ~typer2 ~ilist2 =
   List.fold_left ilist1 ~init:AlleleMap.empty ~f:(to_fold typer1)
   |> fun m -> List.fold_left ilist2 ~init:m ~f:(to_fold typer2)
   |> AlleleMap.bindings
-  |> List.sort ~cmp:compare
   |> List.map ~f:(fun (a, l) ->
       (a, count_consecutive_doubles l |> compress_counts))
+  |> List.sort ~cmp:(fun (_a1, s1) (_a2, s2) ->
+      -1 * compare (List.length s1) (List.length s2))
 
 let against_all_pairs eval nested_map_bindings =
   List.map nested_map_bindings ~f:(fun (sample, type_assoc) ->

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -346,7 +346,7 @@ let output ?(max_allele_rows_to_print=max_int) ?summary_by oc analyze_samples_ou
     value_row_printer comp_assoc;
     let sub_rows = setup_sub_row comp_assoc in
     let mx_rows = List.fold_left ~init:min_int ~f:(fun x (r, _) -> max x r) sub_rows in
-    for r = 0 to mx_rows - 1 do
+    for r = 0 to (min max_allele_rows_to_print mx_rows) - 1 do
       fprintf oc "%*s " smpl_width " ";
       sub_row_printer sub_rows r
     done);

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -278,10 +278,12 @@ let to_metric = function
         let p = normalize (sum_confidence asc1) asc1 in
         let q = normalize (sum_confidence asc2) asc2 in
         try
-          Statistics.Measures.discrete_kl_divergence ~p ~q
+          Statistics.Measures.discrete_kl_divergence ~d:1e-10 ~p ~q ()
         with (Invalid_argument m) ->
-          eprintf "%s returning infinity. p %s vs q %s\n" m
+          eprintf "%s returning infinity. p: %0.20f %s vs q: %0.20f %s\n" m
+            (List.map p ~f:snd |> Array.of_list |> Util.Array.sumf)
             (String.concat ";" (List.map p ~f:(fun (s, c) -> sprintf "%s:%0.2f" s c)))
+            (List.map q ~f:snd |> Array.of_list |> Util.Array.sumf)
             (String.concat ";" (List.map q ~f:(fun (s, c) -> sprintf "%s:%0.2f" s c))) ;
           infinity
 

--- a/src/lib/prohlatype.ml
+++ b/src/lib/prohlatype.ml
@@ -1,14 +1,24 @@
 
 open Std
 
-let suffix = ".txt"
-let filename_regex = Re_posix.compile_pat ("([^/]+)/([^/]+)_[^/]+_(nuc|gen)" ^ suffix)
+let suffix = "(.txt)?$"
+
+(* The nuc/gen .txt are all optional at the moment, so we need the '$'
+   to bind to the end! *)
+let filename_regex =
+  Re_posix.compile_pat ("([^/]+)/([^/]+)_[^/]+(_(nuc|gen))?" ^ suffix)
 
 let allele_to_hla_class s =
   if String.get s 0 = 'D' then II else I
 
 let parse (fname, re_group) =
   let run = Re.Group.get re_group 2 in
+  let run =
+    if String.contains run '_' then
+      String.sub run 0 (String.index run '_')
+    else
+      run
+  in
   let ic = open_in fname in
   let rec loop acc =
     try
@@ -32,7 +42,7 @@ let parse (fname, re_group) =
   in
   run, ilst
 
-let scan_directory dir =
+let scan_directory (dir : string) : ((sample * info list) list) =
   let rec loop acc = function
     | [] -> acc
     | dir :: t ->

--- a/src/lib/seq2HLA.ml
+++ b/src/lib/seq2HLA.ml
@@ -7,7 +7,7 @@ let filename_regex = Re_posix.compile_pat ("(.+)-Class(I{1,2})" ^ suffix)
 let to_hla_class = function
   | "I" -> I
   | "II" -> II
-  | s -> raise (invalid_arg ("Unrecognized HLA class : " ^ s))
+  | s -> invalid_arg ("Unrecognized HLA class : " ^ s)
 
 let parse fname =
   let cls_match = Re.exec filename_regex (Filename.basename fname) in

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -34,3 +34,5 @@ let info_to_string { hla_class; allele; qualifier; confidence} =
     allele qualifier confidence
 
 module InfoMap = Map.Make (struct type t = info let compare = compare end)
+
+type sample = string

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -4,12 +4,12 @@ open Printf
 
 module StringMap = Map.Make (struct type t = string let compare = compare end)
 
+(* Combine assocation lists, with list values, by their string keys. *)
 let join_by_fst lst =
-  List.fold_left lst ~f:(fun acc (run, inf) ->
-    match StringMap.find run acc with
-    | exception Not_found -> StringMap.add run inf acc
-    | clst -> StringMap.add run (clst @ inf) acc)
-        ~init:StringMap.empty
+  List.fold_left lst ~init:StringMap.empty ~f:(fun acc (run, inf) ->
+      match StringMap.find run acc with
+      | exception Not_found -> StringMap.add run inf acc
+      | clst -> StringMap.add run (clst @ inf) acc)
   |> StringMap.bindings
 
 let float_of_string_nanable s = try float_of_string s with Failure _ -> nan
@@ -21,6 +21,10 @@ let hla_class_to_string = function | I -> "1" | II -> "2"
 (* This type is a place holder in case we want to
    make a full ADT of MHC alleles in the future. *)
 type allele = string
+
+(** A sample (aka run) is an obvservation for which we may have multiple
+    [info]'s. *)
+type sample = string
 
 type info =
   { hla_class   : hla_class
@@ -35,4 +39,3 @@ let info_to_string { hla_class; allele; qualifier; confidence} =
 
 module InfoMap = Map.Make (struct type t = info let compare = compare end)
 
-type sample = string


### PR DESCRIPTION
This PR adds discrete KL divergence as a metric for comparison of HLA-types. This branch depends upon an yet unpushed-to-opam branch of `oml` so an `opam pin` is required. The features are complete but may require a bit more tuning as we evaluate the usefulness. For these 2 reasons, I'll open the PR but **not** close it for a little while.