### PR TITLE
Parse seq2 hla ambiguity

### DIFF
--- a/src/lib/athlates.ml
+++ b/src/lib/athlates.ml
@@ -26,11 +26,13 @@ let parse ?(equal_pairs=`MostLikelyPair) (fname, re_group) =
               ; allele     = allele1
               ; qualifier  = ""
               ; confidence = float_of_string_nanable confidence
+              ; typer_spec = ""
               },
               { hla_class  = allele_to_hla_class allele2
               ; allele     = allele2
               ; qualifier  = ""
               ; confidence = float_of_string_nanable confidence
+              ; typer_spec = ""
               })
         in
         loop true (a1 :: a2 :: acc)

--- a/src/lib/athlates.ml
+++ b/src/lib/athlates.ml
@@ -12,7 +12,7 @@ let allele_to_hla_class s =
 
 let parse ?(equal_pairs=`MostLikelyPair) (fname, re_group) =
   let open Info in
-  let run = Re.Group.get re_group 1 in
+  let sample = Re.Group.get re_group 1 in
   let ic = open_in fname in
   let rec loop found_header acc =
     try
@@ -64,7 +64,7 @@ let parse ?(equal_pairs=`MostLikelyPair) (fname, re_group) =
             | a :: [] -> [a; a] (* Preserve pair to signal homozygosity *)
             | lst     -> lst
   in
-  run, alleles
+  sample, alleles
 
 let scan_directory ?equal_pairs dir =
   let rec loop acc = function
@@ -86,5 +86,4 @@ let scan_directory ?equal_pairs dir =
   loop [] [dir]
   |> List.map ~f:(parse ?equal_pairs)
   |> join_by_fst
-  |> List.sort ~cmp:compare  (* sort by keys aka runs *)
-
+  |> List.sort ~cmp:compare  (* sort by keys (samples). *)

--- a/src/lib/athlates.ml
+++ b/src/lib/athlates.ml
@@ -11,6 +11,7 @@ let allele_to_hla_class s =
   if String.get s 0 = 'D' then II else I
 
 let parse ?(equal_pairs=`MostLikelyPair) (fname, re_group) =
+  let open Info in
   let run = Re.Group.get re_group 1 in
   let ic = open_in fname in
   let rec loop found_header acc =

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -40,10 +40,10 @@ module HlarpOutputFiles = struct
         let info, tl = Info.input_as_csv_row ~file ic in
         let sample =
           match tl with
-          | [sample] -> sample
-          | lst ->
-              invalid_argf "Too many sample names after info: %s"
-                (String.concat "," lst)
+          | [s] -> s
+          | []  -> invalid_argf "Missing sample name in: %s" file
+          | lst -> invalid_argf "Too many sample names after info: %s, in %s."
+                    (String.concat "," lst) file
         in
         let key = if use_basename then basename else file in
         match SampleMap.find sample m with

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -40,7 +40,7 @@ module HlarpOutputFiles = struct
         let line = input_line ic in
         let sample, info =
           match Re.split (Re.char ',' |> Re.compile) line with
-          | cls_s :: all_s :: qul_s :: con_s :: sample :: [] ->
+          | cls_s :: all_s :: qul_s :: con_s :: typer_spec :: sample :: [] ->
               sample
               , { hla_class =
                     if cls_s = "1" then I else
@@ -49,6 +49,7 @@ module HlarpOutputFiles = struct
                 ; allele = all_s
                 ; qualifier = qul_s
                 ; confidence = float_of_string_nanable con_s
+                ; typer_spec
               }
           | _ -> invalid_arg
                     (sprintf "can't parse Hlarp input line %s from %s"

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -5,7 +5,7 @@ module SampleMap = Map.Make (struct type t = sample let compare = compare end)
 module AlleleMap = Map.Make (struct type t = allele let compare = compare end)
 
 type directory = string
-type scanner = directory -> (sample * info list) list
+type scanner = directory -> (sample * Info.t list) list
 
 type source = string
 
@@ -37,23 +37,13 @@ module HlarpOutputFiles = struct
     let _hdr = input_line ic in
     let rec loop m =
       try
-        let line = input_line ic in
-        let sample, info =
-          match Re.split (Re.char ',' |> Re.compile) line with
-          | cls_s :: all_s :: qul_s :: con_s :: typer_spec :: sample :: [] ->
-              sample
-              , { hla_class =
-                    if cls_s = "1" then I else
-                      if cls_s = "2" then II else
-                        invalid_arg (sprintf "unrecognized cls: %s" cls_s)
-                ; allele = all_s
-                ; qualifier = qul_s
-                ; confidence = float_of_string_nanable con_s
-                ; typer_spec
-              }
-          | _ -> invalid_arg
-                    (sprintf "can't parse Hlarp input line %s from %s"
-                      line file)
+        let info, tl = Info.input_as_csv_row ~file ic in
+        let sample =
+          match tl with
+          | [sample] -> sample
+          | lst ->
+              invalid_argf "Too many sample names after info: %s"
+                (String.concat "," lst)
         in
         let key = if use_basename then basename else file in
         match SampleMap.find sample m with
@@ -155,8 +145,8 @@ let colon_regex = Re_posix.compile_pat ":"
 
 let to_allele ?resolution ai =
   match resolution with
-  | None   -> ai.allele
-  | Some n -> List.take (Re.split colon_regex ai.allele) n
+  | None   -> ai.Info.allele
+  | Some n -> List.take (Re.split colon_regex ai.Info.allele) n
               |> String.concat ":"
 
 module AlleleSet = Set.Make (struct type t = allele let compare = compare end)
@@ -174,10 +164,10 @@ let jaccard ?(zero_on_empty=true) s1 s2 =
     (float inter) /. (float union)
 
 let loci_prefix_filter p ai =
-  Re.execp (Re_posix.compile_pat ("^" ^ p)) ai.allele
+  Re.execp (Re_posix.compile_pat ("^" ^ p)) ai.Info.allele
 
 let hla_class_filter c ai =
-  ai.hla_class = c
+  ai.Info.hla_class = c
 
 let count_consecutive_doubles = function
   | []      -> []
@@ -256,6 +246,7 @@ let remove_and_assoc el list =
 (* Reduce the [info]'s to have a unique allele resolution.
    ex. A*01:01:01:01 -> A*01:01 and 2nd pair will get "x2" appended. *)
 let keyed_by_allele_info_assoc ?resolution ?(label_homozygous=true) =
+  let open Info in
   let to_allele = to_allele ?resolution in
   List.fold_left ~init:[] ~f:(fun acc ai ->
     let k = to_allele ai in
@@ -273,7 +264,7 @@ let set_of_assoc_keys l =
 
 let sum_confidence p =
   let open Oml in
-  List.map p ~f:(fun (_, ai) -> ai.confidence)
+  List.map p ~f:(fun (_, ai) -> ai.Info.confidence)
   |> Array.of_list
   |> Util.Array.sumf
 
@@ -289,7 +280,7 @@ let normalize sum assoc =
     let oon = 1. /. (float (List.length assoc)) in
     List.map ~f:(fun (k, _) -> k, oon) assoc
   else
-    List.map ~f:(fun (k, ai) -> k, ai.confidence /. sum) assoc
+    List.map ~f:(fun (k, ai) -> k, ai.Info.confidence /. sum) assoc
 
 let describe_distr p =
   String.concat ";" (List.map p ~f:(fun (s, c) -> sprintf "\"%s\",%0.20f" s c))

--- a/src/lib/compare.ml
+++ b/src/lib/compare.ml
@@ -1,15 +1,12 @@
 
 open Std
 
-module SampleMap = Map.Make (struct type t = sample let compare = compare end)
-module AlleleMap = Map.Make (struct type t = allele let compare = compare end)
-
 type directory = string
 type scanner = directory -> (sample * Info.t list) list
 
 type source = string
 
-(* When we want to compare multiple runs from the same source type
+(* When we want to compare multiple samples (runs) from the same source type
    (ex. Seq2HLA dir1, dir2 ..) use this method to create a prefix function
    that appends a number to the source if there are multiple and
    create source. *)

--- a/src/lib/optiType.ml
+++ b/src/lib/optiType.ml
@@ -22,6 +22,7 @@ let parse fname =
       failwith ("Unsupported header row: " ^ hdr)
     end
   else
+    let open Info in
     let info allele =
       { allele
       ; hla_class  = I

--- a/src/lib/optiType.ml
+++ b/src/lib/optiType.ml
@@ -23,7 +23,12 @@ let parse fname =
     end
   else
     let info allele =
-      { hla_class = I ; allele ; qualifier = ""; confidence = nan}
+      { allele
+      ; hla_class  = I
+      ; qualifier  = ""
+      ; confidence = nan
+      ; typer_spec = ""
+      }
     in
     let lst =
       Scanf.sscanf (input_line ic)

--- a/src/lib/output.ml
+++ b/src/lib/output.ml
@@ -2,7 +2,7 @@
 open Std
 
 let out_channel oc run_assoc =
-  fprintf oc "%srun\n" Info.csv_header;
+  fprintf oc "%s,run\n" Info.csv_header;
   List.iter run_assoc ~f:(fun (run, lst) ->
     List.sort ~cmp:compare lst
     |> List.iter ~f:(fun i ->

--- a/src/lib/output.ml
+++ b/src/lib/output.ml
@@ -4,11 +4,12 @@ open Std
 let nan_is_empty f = if f <> f then "" else sprintf "%f" f
 
 let out_channel oc run_assoc =
-  fprintf oc "class,allele,qualifier,confidence,run\n";
+  fprintf oc "class,allele,qualifier,confidence,typer specific,run\n";
   List.iter run_assoc ~f:(fun (run, lst) ->
     List.sort ~cmp:compare lst
-    |> List.iter ~f:(fun {hla_class; allele; qualifier; confidence} ->
-      fprintf oc "%s,%s,%s,%s,%s\n"
+    |> List.iter ~f:(fun {hla_class; allele; qualifier; confidence; typer_spec} ->
+      fprintf oc "%s,%s,%s,%s,%s,%s\n"
         (hla_class_to_string hla_class)
-        allele qualifier (nan_is_empty confidence) run))
+        allele qualifier (nan_is_empty confidence) typer_spec
+        run))
 

--- a/src/lib/output.ml
+++ b/src/lib/output.ml
@@ -1,15 +1,10 @@
 
 open Std
 
-let nan_is_empty f = if f <> f then "" else sprintf "%f" f
-
 let out_channel oc run_assoc =
-  fprintf oc "class,allele,qualifier,confidence,typer specific,run\n";
+  fprintf oc "%srun\n" Info.csv_header;
   List.iter run_assoc ~f:(fun (run, lst) ->
     List.sort ~cmp:compare lst
-    |> List.iter ~f:(fun {hla_class; allele; qualifier; confidence; typer_spec} ->
-      fprintf oc "%s,%s,%s,%s,%s,%s\n"
-        (hla_class_to_string hla_class)
-        allele qualifier (nan_is_empty confidence) typer_spec
-        run))
-
+    |> List.iter ~f:(fun i ->
+        Info.output_as_csv_row oc i;
+        fprintf oc ",%s\n" run))

--- a/src/lib/output.ml
+++ b/src/lib/output.ml
@@ -1,10 +1,10 @@
 
 open Std
 
-let out_channel oc run_assoc =
-  fprintf oc "%s,run\n" Info.csv_header;
-  List.iter run_assoc ~f:(fun (run, lst) ->
+let out_channel oc sample_assoc =
+  fprintf oc "%s,sample\n" Info.csv_header;
+  List.iter sample_assoc ~f:(fun (sample, lst) ->
     List.sort ~cmp:compare lst
     |> List.iter ~f:(fun i ->
         Info.output_as_csv_row oc i;
-        fprintf oc ",%s\n" run))
+        fprintf oc ",%s\n" sample))

--- a/src/lib/prohlatype.ml
+++ b/src/lib/prohlatype.ml
@@ -12,12 +12,12 @@ let allele_to_hla_class s =
   if String.get s 0 = 'D' then II else I
 
 let parse (fname, re_group) =
-  let run = Re.Group.get re_group 2 in
-  let run =
-    if String.contains run '_' then
-      String.sub run 0 (String.index run '_')
+  let sample = Re.Group.get re_group 2 in
+  let sample =
+    if String.contains sample '_' then
+      String.sub sample 0 (String.index sample '_')
     else
-      run
+      sample
   in
   let ic = open_in fname in
   let rec loop acc =
@@ -42,7 +42,7 @@ let parse (fname, re_group) =
       Printf.eprintf "dropping %s because of %s\n" fname (Printexc.to_string e);
       []
   in
-  run, ilst
+  sample, ilst
 
 let scan_directory (dir : string) : ((sample * Info.t list) list) =
   let rec loop acc = function
@@ -65,4 +65,3 @@ let scan_directory (dir : string) : ((sample * Info.t list) list) =
   |> List.map ~f:parse
   |> join_by_fst
   |> List.sort ~cmp:compare
-

--- a/src/lib/prohlatype.ml
+++ b/src/lib/prohlatype.ml
@@ -25,6 +25,7 @@ let parse (fname, re_group) =
       let line = input_line ic in
       let confidence, allele = Scanf.sscanf line "%s\t%s" (fun c a -> (c, a)) in
       let info =
+        let open Info in
         { hla_class = allele_to_hla_class allele
         ; qualifier = ""
         ; allele
@@ -43,7 +44,7 @@ let parse (fname, re_group) =
   in
   run, ilst
 
-let scan_directory (dir : string) : ((sample * info list) list) =
+let scan_directory (dir : string) : ((sample * Info.t list) list) =
   let rec loop acc = function
     | [] -> acc
     | dir :: t ->

--- a/src/lib/prohlatype.ml
+++ b/src/lib/prohlatype.ml
@@ -29,6 +29,7 @@ let parse (fname, re_group) =
         ; qualifier = ""
         ; allele
         ; confidence = float_of_string_nanable confidence
+        ; typer_spec = ""
         }
       in
       loop (info :: acc)

--- a/src/lib/seq2HLA.ml
+++ b/src/lib/seq2HLA.ml
@@ -11,7 +11,7 @@ let to_hla_class = function
 
 let parse fname =
   let cls_match = Re.exec filename_regex (Filename.basename fname) in
-  let run = Re.Group.get cls_match 1 in
+  let sample = Re.Group.get cls_match 1 in
   let cls = to_hla_class (Re.Group.get cls_match 2) in
   let ic = open_in fname in
   let hdr = input_line ic in
@@ -52,7 +52,7 @@ let parse fname =
         loop (a2 :: a1 :: acc)
       with End_of_file ->
         close_in ic;
-        (run, acc)
+        (sample, acc)
     in
     loop []
 
@@ -66,4 +66,4 @@ let scan_directory dir =
   |> List.dedup
   |> List.map ~f:(fun f -> parse (Filename.concat dir f))
   |> join_by_fst
-  |> List.sort ~cmp:compare  (* sort by keys aka runs *)
+  |> List.sort ~cmp:compare  (* sort by keys (sample's) *)

--- a/src/lib/seq2HLA.ml
+++ b/src/lib/seq2HLA.ml
@@ -28,6 +28,7 @@ let parse fname =
         else
           allele, "ambiguity=false"
     in
+    let open Info in
     let rec loop acc =
       try
         let a1, a2 =

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -31,11 +31,12 @@ type info =
   ; allele      : allele
   ; qualifier   : string
   ; confidence  : float
+  (* store typer specific information in free form text. *)
+  ; typer_spec  : string
   }
 
-let info_to_string { hla_class; allele; qualifier; confidence} =
-  sprintf "%s-%s-%s-%f" (hla_class_to_string hla_class)
-    allele qualifier confidence
+let info_to_string { hla_class; allele; qualifier; confidence; typer_spec} =
+  sprintf "%s-%s-%s-%f-%s" (hla_class_to_string hla_class)
+    allele qualifier confidence typer_spec
 
 module InfoMap = Map.Make (struct type t = info let compare = compare end)
-

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -2,6 +2,8 @@
 include Nonstd
 open Printf
 
+let invalid_argf fmt = ksprintf invalid_arg fmt
+
 module StringMap = Map.Make (struct type t = string let compare = compare end)
 
 (* Combine assocation lists, with list values, by their string keys. *)
@@ -26,17 +28,51 @@ type allele = string
     [info]'s. *)
 type sample = string
 
-type info =
-  { hla_class   : hla_class
-  ; allele      : allele
-  ; qualifier   : string
-  ; confidence  : float
-  (* store typer specific information in free form text. *)
-  ; typer_spec  : string
-  }
+let nan_is_empty f = if f <> f then "" else sprintf "%f" f
 
-let info_to_string { hla_class; allele; qualifier; confidence; typer_spec} =
-  sprintf "%s-%s-%s-%f-%s" (hla_class_to_string hla_class)
-    allele qualifier confidence typer_spec
+module Info = struct
 
-module InfoMap = Map.Make (struct type t = info let compare = compare end)
+  type t =
+    { hla_class   : hla_class
+    ; allele      : allele
+    ; qualifier   : string
+    ; confidence  : float
+    (* store typer specific information in free form text. *)
+    ; typer_spec  : string
+    }
+
+  let to_string { hla_class; allele; qualifier; confidence; typer_spec} =
+    sprintf "%s-%s-%s-%f-%s" (hla_class_to_string hla_class)
+      allele qualifier confidence typer_spec
+
+  let csv_header = "class,allele,qualifier,confidence,typer specific"
+
+  let output_as_csv_row oc {hla_class; allele; qualifier; confidence; typer_spec} =
+    fprintf oc "%s,%s,%s,%s,%s"
+      (hla_class_to_string hla_class)
+      allele
+      qualifier
+      (nan_is_empty confidence)
+      typer_spec
+
+  let comma_regex = Re.(compile (char ','))
+
+  let input_as_csv_row ?(file="") ic =
+    let line = input_line ic in
+    match Re.split comma_regex line with
+    | cls_s :: allele :: qualifier :: con_s :: typer_spec :: tl ->
+        { hla_class =
+          if cls_s = "1" then I else
+            if cls_s = "2" then II else
+              invalid_argf "unrecognized cls: %s" cls_s
+        ; allele
+        ; qualifier
+        ; confidence  = float_of_string_nanable con_s
+        ; typer_spec
+        }, tl
+    | _ ->
+        invalid_argf "can't parse Hlarp input line %s from %s" line file
+
+end (* Info *)
+
+module InfoMap = Map.Make (struct type t = Info.t let compare = compare end)

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -8,10 +8,10 @@ module StringMap = Map.Make (struct type t = string let compare = compare end)
 
 (* Combine assocation lists, with list values, by their string keys. *)
 let join_by_fst lst =
-  List.fold_left lst ~init:StringMap.empty ~f:(fun acc (run, inf) ->
-      match StringMap.find run acc with
-      | exception Not_found -> StringMap.add run inf acc
-      | clst -> StringMap.add run (clst @ inf) acc)
+  List.fold_left lst ~init:StringMap.empty ~f:(fun acc (r, inf) ->
+      match StringMap.find r acc with
+      | exception Not_found -> StringMap.add r inf acc
+      | clst -> StringMap.add r (clst @ inf) acc)
   |> StringMap.bindings
 
 let float_of_string_nanable s = try float_of_string s with Failure _ -> nan
@@ -27,6 +27,10 @@ type allele = string
 (** A sample (aka run) is an obvservation for which we may have multiple
     [info]'s. *)
 type sample = string
+
+module SampleMap = Map.Make (struct type t = sample let compare = compare end)
+module AlleleMap = Map.Make (struct type t = allele let compare = compare end)
+
 
 let nan_is_empty f = if f <> f then "" else sprintf "%f" f
 


### PR DESCRIPTION
This fixes #25.

To be clear, the latest version of `hlarp` doesn't crash with this error, but just propagates `seq2HLA`'s ambiguity apostrophe at the end of the allele name into the output. This PR creates a new field `typer_spec` as part of the `Info.t` record to carry "unparsed" (untyped) parser specific information into the normalized output.

For example the new output looks like:

```
/hlarp_cli.native seq2HLA /path/concatseq2hla-workdir/
class,allele,qualifier,confidence,typer specific,sample
1,A*02:01,,0.001507,ambiguity=true,rna-CA209009_11_8_T_C2D8
1,A*29:02,,0.000001,ambiguity=false,rna-CA209009_11_8_T_C2D8
1,B*44:02,,0.000000,ambiguity=true,rna-CA209009_11_8_T_C2D8
1,B*44:02,,0.048383,ambiguity=false,rna-CA209009_11_8_T_C2D8
1,C*05:01,,0.038153,ambiguity=false,rna-CA209009_11_8_T_C2D8
1,C*16:01,,0.067506,ambiguity=false,rna-CA209009_11_8_T_C2D8
2,DQA1*02:01,,,ambiguity=false,rna-CA209009_11_8_T_C2D8
2,DQA1*02:01,,0.000000,ambiguity=false,rna-CA209009_11_8_T_C2D8
2,DQB1*02:02,,0.000000,ambiguity=true,rna-CA209009_11_8_T_C2D8
2,DQB1*03:02,,0.000407,ambiguity=true,rna-CA209009_11_8_T_C2D8
2,DRB1*07:01,,0.000000,ambiguity=false,rna-CA209009_11_8_T_C2D8
2,DRB1*14:103,,0.279392,ambiguity=false,rna-CA209009_11_8_T_C2D8
```
