### PR TITLE
Reform compare argument parsing

### DIFF
--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -1,7 +1,7 @@
 (** A tool to normalize HLA typing output.
 
-class,allele,qualifier,confidence
-1,HLA-A*02:01,G,0.9
+class,allele,qualifier,confidence,typer_spec,sample
+1,HLA-A*02:01,G,0.9,,Patient_1
 *)
 
 open Hlarp
@@ -27,10 +27,10 @@ let multiple seqlst optlst athlst prolst do_not_prefix =
 
 let compare resolution classes loci max_allele_rows_to_print metrics summary_by
   (* Input *)
-  seqlst optlst athlst prolst filelst =
+  pos_args =
   let classes = match classes with | [] -> None | l -> Some l in
   let loci = match loci with | [] -> None | l -> Some l in
-  let nmp  = Compare.nested_maps ~seqlst ~optlst ~athlst ~prolst ~filelst () in
+  let nmp  = Compare.nested_maps pos_args in
   let azo  = Compare.analyze_samples ?loci ?resolution ?classes ~metrics nmp in
   Compare.output ?max_allele_rows_to_print ~summary_by stdout azo
 
@@ -112,10 +112,55 @@ let () =
         & info arg_lst ~docv:"DIR"
             ~doc:(sprintf "Directory to search for %s output (repeatable)." name))
   in
-  let seq_arg = to_directory_arg "Seq2HLA" [ Compare.seq2hl_file_arg ] in
-  let opt_arg = to_directory_arg "Optitype" [ Compare.optitype_file_arg ] in
-  let ath_arg = to_directory_arg "ATHLATES" [ Compare.athlates_file_arg ] in
-  let pro_arg = to_directory_arg "Prohlatype" [ Compare.prohlatype_file_arg ] in
+  let seq_arg = to_directory_arg "Seq2HLA" [ "seq2HLA" ] in
+  let opt_arg = to_directory_arg "Optitype" [ "optitype" ] in
+  let ath_arg = to_directory_arg "ATHLATES" [ "athlates" ] in
+  let pro_arg = to_directory_arg "Prohlatype" [ "prohlatype" ] in
+  let typers_as_pos_args =
+    let is_file f o arg =
+      if Sys.file_exists f then
+        `Ok o
+      else
+        `Error (sprintf "not a file %s in %s argument" f arg)
+    in
+    let is_dir s o arg =
+      if Sys.file_exists s && Sys.is_directory s then
+        `Ok o
+      else
+        `Error (sprintf "not a directory %s in %s argument" s arg)
+    in
+    let tparser s =
+      try
+        let i = String.index s '=' in
+        let n = String.length s in
+        let l = String.sub s 0 i in
+        let r = String.sub s (i + 1) (n - i - 1) in
+        match l with
+        | "hlarp-file" -> is_file r (`HlarpFile r) l
+        | "seq2HLA"    -> is_dir r (`seq2HLA r) l
+        | "optitype"   -> is_dir r (`OptiType r) l
+        | "athlates"   -> is_dir r (`ATHLATES r) l
+        | "prohlatype" -> is_dir r (`Prohlatype r) l
+        | s            -> `Error ("unrecognized typer spec: " ^ s)
+      with Not_found ->
+        `Error (sprintf "Failed to find '=' in typer specific argument: %s" s)
+    in
+    let tprinter fmt = function
+      | `HlarpFile f  -> Format.fprintf fmt "Hlarp file %s" f
+      | `seq2HLA d    -> Format.fprintf fmt "seq2HLA %s" d
+      | `OptiType d   -> Format.fprintf fmt "OptiType %s" d
+      | `ATHLATES d   -> Format.fprintf fmt "ATHLATES %s" d
+      | `Prohlatype d -> Format.fprintf fmt "Prohlatype %s" d
+    in
+    Arg.(non_empty
+        & pos_all (tparser, tprinter) []
+        & info
+          ~docv:"[seq2HLA|optitype|athlates|prohlatype|hlarp-file]=[DIRECTORY|FILE]"
+          ~doc:"Directories or files (as in the last case) prefixed by the \
+                name of the typer and an equal sign, to specify where to look \
+                for aggregation or comparison HLA data."
+          [])
+  in
   let multiple =
     let pre_flg =
       Arg.(value & flag & info ["prefix"]
@@ -161,11 +206,6 @@ let () =
                       Specify multiple loci to get separate analyses.\
                       This argument will supersede any class grouping arguments.")
     in
-    let files_arg =
-      Arg.(value & opt_all file []
-          & info [ Compare.hlarp_file_arg ] ~docv:"FILE"
-            ~doc:"Load, parse and use for comparison a file previously written by the aggregate format.")
-    in
     let max_allele_rows_to_print_arg =
       Arg.(value & opt (some int) None
           & info ["max-allele-rows-to-print"]
@@ -190,8 +230,7 @@ let () =
             $ metrics_flag
             $ summary_by_arg
             (* Input *)
-            $ seq_arg $ opt_arg $ ath_arg $ pro_arg
-            $ files_arg
+            $ typers_as_pos_args
         , info "compare"
             ~doc:"Scan multiple directories (of possibly different formats) and compare the results after aggregating on a per run basis.")
   in

--- a/src/app/hlarp_cli.ml
+++ b/src/app/hlarp_cli.ml
@@ -32,7 +32,8 @@ let compare resolution classes loci max_allele_rows_to_print metrics summary_by
   let loci = match loci with | [] -> None | l -> Some l in
   let nmp  = Compare.nested_maps pos_args in
   let azo  = Compare.analyze_samples ?loci ?resolution ?classes ~metrics nmp in
-  Compare.output ?max_allele_rows_to_print ~summary_by stdout azo
+  Compare.(output ?max_allele_rows_to_print ~summary_by stdout
+    (strip_empty_comparisons (Some stdout) azo))
 
 let () =
   let open Cmdliner in


### PR DESCRIPTION
This PR fixes #23 by changing the format of `compare` arguments.
The TL;DR is
```
hlarp compare optitype=/path/to/opti_dir athlates=/path/to/ath_dir ...
```
instead of
```
hlarp compare --optitype /path/to/opti_dir --athlates /path/to/ath_dir ...
```

this mostly simplifies some internal logic. There is also a small bug fix for dealing with samples that have no comparisons.
